### PR TITLE
Uploaded media now converted to webp for base image

### DIFF
--- a/src/Churchee.Common/Abstractions/Utilities/IImageProcessor.cs
+++ b/src/Churchee.Common/Abstractions/Utilities/IImageProcessor.cs
@@ -24,7 +24,16 @@ namespace Churchee.Common.Abstractions.Utilities
         /// <param name="width">With of the desired crop</param>
         /// <param name="extension">.png, .jpg, .webp etc.</param>
         /// <param name="cancellationToken">Pass through a cancelation token</param>
-        /// <returns></returns>
+        /// <returns>Cropped Image Stream</returns>
         Task<Stream> CreateCropAsync(Stream stream, int width, string extension, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Convert any image to webp format, resizing if necessary
+        /// </summary>
+        /// <param name="stream">Source Stream</param>
+        /// <param name="cancellationToken">Pass through a cancelation token</param>
+        /// <returns>WebP Image Stream</returns>
+        Task<Stream> ConvertToWebP(Stream stream, CancellationToken cancellationToken);
+
     }
 }


### PR DESCRIPTION
This pull request introduces support for converting uploaded images to the WebP format before storage and updates the media item creation workflow accordingly. The main changes include adding a new method to the `IImageProcessor` interface, implementing the conversion logic, and updating the command handler to use the new functionality.

**Image Processing Enhancements:**

* Added a new `ConvertToWebP` method to the `IImageProcessor` interface, allowing conversion of any image stream to WebP format, with optional resizing.
* Implemented the `ConvertToWebP` method in `DefaultImageProcessor`, which identifies the image, resizes it if necessary (max width 1920), and encodes it as a lossless, high-quality WebP image.
* Refactored internal image processing logic to support custom encoders, improving flexibility for future image format support. 

**Media Item Creation Workflow:**

* Updated `CreateMediaItemCommandHandler` to inject and use `IImageProcessor`, converting all uploaded images to WebP before saving them to blob storage. The saved file path is updated to use the `.webp` extension.