### PR TITLE
Added Video Module Tests

### DIFF
--- a/Churchee.sln
+++ b/Churchee.sln
@@ -125,6 +125,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Churchee.Infrastructure.Sas
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Churchee.Data.EntityFramework.Site.Tests", "test\Churchee.Data.EntityFramework.Site.Tests\Churchee.Data.EntityFramework.Site.Tests.csproj", "{6F75A9A9-6271-4E17-A6E4-AA8906D60FB7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Churchee.Module.Videos.Tests", "test\Churchee.Module.Videos.Tests\Churchee.Module.Videos.Tests.csproj", "{188E2B8F-3811-642A-F65C-7C56253D4FB5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -319,6 +321,10 @@ Global
 		{6F75A9A9-6271-4E17-A6E4-AA8906D60FB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6F75A9A9-6271-4E17-A6E4-AA8906D60FB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6F75A9A9-6271-4E17-A6E4-AA8906D60FB7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{188E2B8F-3811-642A-F65C-7C56253D4FB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{188E2B8F-3811-642A-F65C-7C56253D4FB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{188E2B8F-3811-642A-F65C-7C56253D4FB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{188E2B8F-3811-642A-F65C-7C56253D4FB5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -375,6 +381,7 @@ Global
 		{0C52ED2B-A566-4020-DE31-0BDAE838A9FF} = {4486B06F-87D4-4920-90BC-5F15BA7376F4}
 		{773F4F1B-BA41-2439-CB66-1642F3292580} = {4B48BE94-D6FB-438A-BFCB-C098EDD771F3}
 		{6F75A9A9-6271-4E17-A6E4-AA8906D60FB7} = {4B48BE94-D6FB-438A-BFCB-C098EDD771F3}
+		{188E2B8F-3811-642A-F65C-7C56253D4FB5} = {187811C7-20D5-435D-83B8-042B3227E714}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {456111D9-BD96-4D2E-94D6-42EF29980C0B}

--- a/test/Churchee.Module.Videos.Tests/Churchee.Module.Videos.Tests.csproj
+++ b/test/Churchee.Module.Videos.Tests/Churchee.Module.Videos.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Ardalis.Specification" Version="8.0.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.4.0" />

--- a/test/Churchee.Module.Videos.Tests/Churchee.Module.Videos.Tests.csproj
+++ b/test/Churchee.Module.Videos.Tests/Churchee.Module.Videos.Tests.csproj
@@ -1,28 +1,30 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.4.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Churchee.Module.Videos\Churchee.Module.Videos.csproj" />
+    <ProjectReference Include="..\Churchee.Test.Helpers\Churchee.Test.Helpers.csproj" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
-
 </Project>

--- a/test/Churchee.Module.Videos.Tests/Entities/VideoTests.cs
+++ b/test/Churchee.Module.Videos.Tests/Entities/VideoTests.cs
@@ -1,0 +1,54 @@
+using Churchee.Test.Helpers.Validation;
+
+namespace Churchee.Module.Videos.Entities
+{
+    public class VideoTests
+    {
+        [Fact]
+        public void DefaultConstructor_InitializesPropertiesToDefaults()
+        {
+            // Act
+            var video = new Video();
+
+            // Assert
+            Assert.Equal(string.Empty, video.VideoUri);
+            Assert.Equal(string.Empty, video.SourceName);
+            Assert.Equal(string.Empty, video.ThumbnailUrl);
+        }
+
+        [Fact]
+        public void ParameterizedConstructor_SetsAllPropertiesCorrectly()
+        {
+            // Arrange
+            var applicationTenantId = Guid.NewGuid();
+            string videoUri = "https://example.com/video.mp4";
+            var publishedDate = new DateTime(2024, 1, 1);
+            string sourceName = "YouTube";
+            string sourceId = "abc123";
+            string title = "Test Video";
+            string description = "A test video.";
+            string thumbnailUrl = "https://example.com/thumb.jpg";
+            string videosPath = "Videos";
+            var pageTypeId = Guid.NewGuid();
+            var before = DateTime.Now;
+
+            // Act
+            var video = new Video(applicationTenantId, videoUri, publishedDate, sourceName, sourceId, title, description, thumbnailUrl, videosPath, pageTypeId);
+            var after = DateTime.Now;
+
+            // Assert
+            video.VideoUri.Should().Be(videoUri);
+            video.PublishedDate.Should().Be(publishedDate);
+            video.ThumbnailUrl.Should().Be(thumbnailUrl);
+            video.SourceName.Should().Be(sourceName);
+            video.SourceId.Should().Be(sourceId);
+            video.SyncDate.Should().BeOnOrAfter(before);
+            video.SyncDate.Should().BeOnOrBefore(after);
+            video.IsSystem.Should().BeTrue();
+            video.PageTypeId.Should().Be(pageTypeId);
+            video.Url.Should().Be($"/{videosPath.ToLowerInvariant()}/{title.ToURL()}");
+            video.Published.Should().BeTrue();
+
+        }
+    }
+}

--- a/test/Churchee.Module.Videos.Tests/Features/Commands/VideosEnabled/VideosEnabledCommandHandlerTests.cs
+++ b/test/Churchee.Module.Videos.Tests/Features/Commands/VideosEnabled/VideosEnabledCommandHandlerTests.cs
@@ -1,0 +1,62 @@
+using Churchee.Common.Abstractions.Auth;
+using Churchee.Common.Abstractions.Storage;
+using Churchee.Common.ResponseTypes;
+using Churchee.Common.Storage;
+using Churchee.Module.Site.Entities;
+using Churchee.Module.Tenancy.Entities;
+using Churchee.Module.Videos.Helpers;
+using Churchee.Test.Helpers.Validation;
+using Moq;
+
+namespace Churchee.Module.Videos.Features.Commands
+{
+    public class VideosEnabledCommandHandlerTests
+    {
+        [Fact]
+        public async Task Handle_CreatesPagesAndTemplates_WhenSettingsAreMissing()
+        {
+            // Arrange
+            var dataStoreMock = new Mock<IDataStore>(MockBehavior.Strict);
+            var currentUserMock = new Mock<ICurrentUser>(MockBehavior.Strict);
+            var settingStoreMock = new Mock<ISettingStore>(MockBehavior.Strict);
+            var applicationTenantId = Guid.NewGuid();
+            string pageName = "videos";
+            var command = new VideosEnabledCommand(pageName);
+            var tenant = new ApplicationTenant(applicationTenantId, "TestTenant", 123);
+
+            currentUserMock.Setup(x => x.GetApplicationTenantId()).ReturnsAsync(applicationTenantId);
+            settingStoreMock.Setup(x => x.GetSettingValue(Settings.VideosNameId, applicationTenantId)).ReturnsAsync((string?)null);
+            settingStoreMock.Setup(x => x.AddSetting(Settings.VideosNameId, applicationTenantId, It.IsAny<string>(), pageName)).Returns(Task.CompletedTask);
+
+            var appTenantRepo = new Mock<IRepository<ApplicationTenant>>();
+            appTenantRepo.Setup(r => r.GetByIdAsync(applicationTenantId, It.IsAny<CancellationToken>())).ReturnsAsync(tenant);
+            dataStoreMock.Setup(x => x.GetRepository<ApplicationTenant>()).Returns(appTenantRepo.Object);
+
+            var pageRepo = new Mock<IRepository<Page>>();
+            pageRepo.Setup(r => r.GetQueryable()).Returns(new System.Collections.Generic.List<Page>().AsQueryable());
+            pageRepo.Setup(r => r.Create(It.IsAny<Page>()));
+            dataStoreMock.Setup(x => x.GetRepository<Page>()).Returns(pageRepo.Object);
+
+            var viewTemplateRepo = new Mock<IRepository<ViewTemplate>>();
+            viewTemplateRepo.Setup(r => r.GetQueryable()).Returns(new System.Collections.Generic.List<ViewTemplate>().AsQueryable());
+            viewTemplateRepo.Setup(r => r.Create(It.IsAny<ViewTemplate>()));
+            dataStoreMock.Setup(x => x.GetRepository<ViewTemplate>()).Returns(viewTemplateRepo.Object);
+
+            var pageTypeRepo = new Mock<IRepository<PageType>>();
+            pageTypeRepo.Setup(r => r.AnyWithFiltersDisabled(It.IsAny<System.Linq.Expressions.Expression<Func<PageType, bool>>>())).Returns(false);
+            pageTypeRepo.Setup(r => r.Create(It.IsAny<PageType>()));
+            dataStoreMock.Setup(x => x.GetRepository<PageType>()).Returns(pageTypeRepo.Object);
+
+            dataStoreMock.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            var handler = new VideosEnabledCommandHandler(dataStoreMock.Object, currentUserMock.Object, settingStoreMock.Object);
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().BeOfType<CommandResponse>();
+        }
+    }
+}

--- a/test/Churchee.Module.Videos.Tests/Features/Commands/VideosEnabled/VideosEnabledCommandTests.cs
+++ b/test/Churchee.Module.Videos.Tests/Features/Commands/VideosEnabled/VideosEnabledCommandTests.cs
@@ -1,0 +1,20 @@
+using Churchee.Test.Helpers.Validation;
+
+namespace Churchee.Module.Videos.Features.Commands
+{
+    public class VideosEnabledCommandTests
+    {
+        [Fact]
+        public void Constructor_SetsPageNameForVideos()
+        {
+            // Arrange
+            string pageName = "videos";
+
+            // Act
+            var command = new VideosEnabledCommand(pageName);
+
+            // Assert
+            command.PageNameForVideos.Should().Be(pageName);
+        }
+    }
+}

--- a/test/Churchee.Module.Videos.Tests/Helpers/PageTypesTests.cs
+++ b/test/Churchee.Module.Videos.Tests/Helpers/PageTypesTests.cs
@@ -1,0 +1,19 @@
+using Churchee.Test.Helpers.Validation;
+
+namespace Churchee.Module.Videos.Helpers
+{
+    public class PageTypesTests
+    {
+        [Fact]
+        public void VideoListingPageTypeId_IsExpectedGuid()
+        {
+            PageTypes.VideoListingPageTypeId.Should().Be(Guid.Parse("655a429f-c01a-4559-9c25-c2c450e7c14d"));
+        }
+
+        [Fact]
+        public void VideoDetailPageTypeId_IsExpectedGuid()
+        {
+            PageTypes.VideoDetailPageTypeId.Should().Be(Guid.Parse("666e214e-bfe7-46ef-84ee-fdcda53c12c3"));
+        }
+    }
+}

--- a/test/Churchee.Module.Videos.Tests/Helpers/SettingsTests.cs
+++ b/test/Churchee.Module.Videos.Tests/Helpers/SettingsTests.cs
@@ -1,0 +1,11 @@
+namespace Churchee.Module.Videos.Helpers
+{
+    public class SettingsTests
+    {
+        [Fact]
+        public void VideosNameId_IsExpectedGuid()
+        {
+            Assert.Equal(Guid.Parse("4379e3d3-fa40-489b-b80d-01c30835fa9d"), typeof(Settings).GetField("VideosNameId")?.GetValue(null));
+        }
+    }
+}

--- a/test/Churchee.Module.Videos.Tests/Registrations/EntityRegistrationsTests.cs
+++ b/test/Churchee.Module.Videos.Tests/Registrations/EntityRegistrationsTests.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace Churchee.Module.Videos.Registrations
+{
+    public class EntityRegistrationsTests
+    {
+        [Fact]
+        public void RegisterEntities_ConfiguresVideoEntity()
+        {
+            // Arrange
+            var modelBuilderMock = new Mock<ModelBuilder>(new object[] { new Microsoft.EntityFrameworkCore.Metadata.Conventions.ConventionSet() }) { CallBase = true };
+            var entityRegistrations = new EntityRegistrations();
+
+            // Act & Assert (should not throw)
+            entityRegistrations.RegisterEntities(modelBuilderMock.Object);
+        }
+    }
+}

--- a/test/Churchee.Module.Videos.Tests/Registrations/ModuleRegistrationTests.cs
+++ b/test/Churchee.Module.Videos.Tests/Registrations/ModuleRegistrationTests.cs
@@ -1,0 +1,22 @@
+﻿using Churchee.Test.Helpers.Validation;
+
+namespace Churchee.Module.Videos.Registrations
+{
+    public class ModuleRegistrationTests
+    {
+        [Fact]
+        public void ModuleRegistration_ShouldReturnExpectedModuleName()
+        {
+            // Arrange
+            var moduleRegistration = new ModuleRegistration();
+
+            // Act
+            string moduleName = moduleRegistration.Name;
+
+
+            // Assert
+            moduleName.Should().NotBeNull();
+            moduleName.Should().Be("Videos");
+        }
+    }
+}

--- a/test/Churchee.Module.Videos.Tests/Specifications/VideoSearchFilterSpecificationTests.cs
+++ b/test/Churchee.Module.Videos.Tests/Specifications/VideoSearchFilterSpecificationTests.cs
@@ -1,0 +1,50 @@
+using Churchee.Module.Videos.Entities;
+using Churchee.Test.Helpers.Validation;
+
+namespace Churchee.Module.Videos.Specifications
+{
+    public class VideoSearchFilterSpecificationTests
+    {
+        [Fact]
+        public void Specification_FiltersVideos_BySearchText()
+        {
+            // Arrange
+            var videos = new List<Video>
+            {
+                new(
+                    Guid.NewGuid(),
+                    "https://example.com/video1",
+                    DateTime.UtcNow,
+                    "TestSource",
+                    "SourceId1",
+                    "Test Video",
+                    "A test video description",
+                    "https://example.com/thumb1.jpg",
+                    "/videos/video1.mp4",
+                    Guid.NewGuid()
+                ),
+                new(
+                    Guid.NewGuid(),
+                    "https://example.com/video2",
+                    DateTime.UtcNow,
+                    "TestSource",
+                    "SourceId2",
+                    "Another",
+                    "Another video description",
+                    "https://example.com/thumb2.jpg",
+                    "/videos/video2.mp4",
+                    Guid.NewGuid()
+                )
+            }.AsQueryable();
+
+            // Act
+            var spec = new VideoSearchFilterSpecification("Test");
+            var predicate = spec.WhereExpressions.First().Filter.Compile();
+            var filtered = videos.Where(predicate).ToList();
+
+            // Assert
+            filtered.Should().HaveCount(1);
+            filtered.First().Title.Should().Be("Test Video");
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a new test project for the Videos module and introduces comprehensive unit tests covering entities, helpers, commands, registrations, and specifications. It also updates the solution file and test project dependencies to support these additions.

**Solution and Project Configuration:**

* Added `Churchee.Module.Videos.Tests` test project to the solution (`Churchee.sln`) and configured its build and project hierarchy settings. [[1]](diffhunk://#diff-4aec1fffeee838305b766845a29a9b9e395c67a8c8ab514e3c63980f27146716R128-R129) [[2]](diffhunk://#diff-4aec1fffeee838305b766845a29a9b9e395c67a8c8ab514e3c63980f27146716R324-R327) [[3]](diffhunk://#diff-4aec1fffeee838305b766845a29a9b9e395c67a8c8ab514e3c63980f27146716R384)
* Updated `Churchee.Module.Videos.Tests.csproj` to include new dependencies (`Testcontainers.MsSql`, updated `coverlet.collector`, and newer versions of `xunit` and `xunit.runner.visualstudio`) and referenced the `Churchee.Test.Helpers` project for shared test utilities.

**New Unit Tests:**

* **Entities and Helpers:**
  - Added tests for the `Video` entity's constructors and default property values.
  - Added tests for helper classes: `PageTypes` and `Settings` to verify expected GUID values. [[1]](diffhunk://#diff-8b7f62e55529fdc76bef332470f67dcf4d960212e300dea5362783628dd66da6R1-R19) [[2]](diffhunk://#diff-578bd97543d2c6ab47de09122b574de21e0b72688acafd46aabbc58ae0494532R1-R11)

* **Features and Specifications:**
  - Added tests for the `VideosEnabledCommand` and its handler to verify correct property assignment and system behavior when settings are missing. [[1]](diffhunk://#diff-b655d42f82c70db6e0ac5975cabfd7d053585a8403c05c4fdadeec974e8fda4aR1-R20) [[2]](diffhunk://#diff-362ba5192e095e05447f52d7026716d42c585510e14ff7e9e89e0c0eda8bacb9R1-R62)
  - Added tests for `VideoSearchFilterSpecification` to ensure filtering logic works as intended.

* **Registrations:**
  - Added tests for `EntityRegistrations` and `ModuleRegistration` to verify entity configuration and module name correctness. [[1]](diffhunk://#diff-75f88931d610e903379757ebcc3be001f7a374d25b70010aaae83fca64335f4cR1-R19) [[2]](diffhunk://#diff-a04bf832f00e50757380c3d08206a53c08ba8a8b753a88b1f1bd481ae5266747R1-R22)