### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/treefishuk/churchee/security/code-scanning/6](https://github.com/treefishuk/churchee/security/code-scanning/6)

To fix the issue, we should add a `permissions` block to the workflow YAML. The most straightforward way is to add it at the workflow root, so it applies to all jobs, unless overridden. For build and test-only workflows that do not push code, create releases, or interact with issues or pull requests, the minimal permission required is typically `contents: read`. Place this block just below the `name:` line and above the `on:` block in `.github/workflows/dotnet.yml`. No new imports, methods, or package dependencies are required; only the YAML needs to be edited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
