### PR TITLE
Added Favicon Support

### DIFF
--- a/src/Churchee.Module.Site/Areas/Site/Models/CreateFaviconModel.cs
+++ b/src/Churchee.Module.Site/Areas/Site/Models/CreateFaviconModel.cs
@@ -1,0 +1,18 @@
+﻿using Churchee.Common.ValueTypes;
+using System.ComponentModel.DataAnnotations;
+
+namespace Churchee.Module.Site.Areas.Site.Models
+{
+    public class CreateFaviconModel
+    {
+        public CreateFaviconModel()
+        {
+            File = new Upload();
+        }
+
+        [Required]
+        [ValidateComplexType]
+        [DataType(DataTypes.MediaUpload)]
+        public Upload File { get; set; }
+    }
+}

--- a/src/Churchee.Module.Site/Areas/Site/Pages/Media/Index.razor
+++ b/src/Churchee.Module.Site/Areas/Site/Pages/Media/Index.razor
@@ -1,6 +1,7 @@
 ﻿@page "/management/media"
 @inherits BasePage
 @using Churchee.Module.Site.Features.CDN.Queries
+@using Churchee.Module.Site.Features.Favicons.Commands
 @using Churchee.Module.Site.Features.Media.Commands
 @using Churchee.Module.Site.Features.Media.Queries
 @using MediatR
@@ -151,6 +152,8 @@
 
     CreateMediaItemModel createModel = new CreateMediaItemModel();
 
+    CreateFaviconModel createFaviconModel = new CreateFaviconModel();
+
     EditMediaItemModel editModel = new EditMediaItemModel();
 
     protected override async Task OnInitializedAsync()
@@ -209,21 +212,63 @@
 
     private async Task AddMediaItem()
     {
-        createModel = new CreateMediaItemModel
+        if(ActiveFolderItem.Path == "Favicons/")
         {
-            File = new Common.ValueTypes.Upload { SupportedFileTypes =  ActiveFolderItem.SupportedFileTypes}
-        };
+            createFaviconModel = new CreateFaviconModel
+            {
+                File = new Common.ValueTypes.Upload { SupportedFileTypes =  ActiveFolderItem.SupportedFileTypes}
+            };
 
-       await DialogService.OpenAsync("Add Media Item", ds =>
-            @<ModalForm InputModel="createModel" OnCancelForm=@(async () => await OnCancelEdit(ds)) OnChange="OnCreateModalFormChange" OnSave=@(async () => await ValidCreateSubmitForm()) />,
-            new DialogOptions() { Width = "700px"}
-        );    
+           await DialogService.OpenAsync("Add Favicon", ds =>
+                @<ModalForm InputModel="createFaviconModel" OnCancelForm=@(async () => await OnCancelEdit(ds)) OnSave=@(async () => await ValidFaviconSubmitForm()) />,
+                new DialogOptions() { Width = "700px"}
+            );
+        }
+        else
+        {
+            createModel = new CreateMediaItemModel
+            {
+                File = new Common.ValueTypes.Upload { SupportedFileTypes =  ActiveFolderItem.SupportedFileTypes}
+            };
+
+           await DialogService.OpenAsync("Add Media Item", ds =>
+                @<ModalForm InputModel="createModel" OnCancelForm=@(async () => await OnCancelEdit(ds)) OnChange="OnCreateModalFormChange" OnSave=@(async () => await ValidMediaItemCreateSubmitForm()) />,
+                new DialogOptions() { Width = "700px"}
+            );
+        }
+
+
 
     }
 
     IEnumerable<GetMediaFoldersQueryResponseItem> Directories = new List<GetMediaFoldersQueryResponseItem>();
 
-    private async Task ValidCreateSubmitForm()
+    private async Task ValidFaviconSubmitForm()
+    {
+        var command = new GenerateFaviconCommand(createFaviconModel.File.Value, activeFolderId.Value);
+
+        var result = await Mediator.Send(command);
+
+        if (result.IsSuccess)
+        {
+            DialogService.Close();
+
+            data = await Mediator.Send(new GetMediaListForFolderQuery(activeFolderId));
+
+            NotificationService.Notify(new NotificationMessage { Severity = NotificationSeverity.Success, Summary = "Media Item Added" });
+        }
+
+        if (!result.IsSuccess)
+        {
+            foreach (var error in result.Errors)
+            {
+                NotificationService.Notify(new NotificationMessage { Severity = NotificationSeverity.Error, Summary = error.Description, Duration = 5000 });
+            }
+        }
+    }
+
+
+    private async Task ValidMediaItemCreateSubmitForm()
     {
         var command = new CreateMediaItemCommand.Builder()
         .SetSupportedFileTypes(ActiveFolderItem.SupportedFileTypes)

--- a/src/Churchee.Module.Site/Features/Favicons/Commands/GenerateFaviconCommand.cs
+++ b/src/Churchee.Module.Site/Features/Favicons/Commands/GenerateFaviconCommand.cs
@@ -1,0 +1,19 @@
+﻿using Churchee.Common.ResponseTypes;
+using MediatR;
+
+namespace Churchee.Module.Site.Features.Favicons.Commands
+{
+    public class GenerateFaviconCommand : IRequest<CommandResponse>
+    {
+        public GenerateFaviconCommand(string base64Content, Guid folderId)
+        {
+            Base64Content = base64Content;
+            FolderId = folderId;
+        }
+
+        public string Base64Content { get; set; }
+
+        public Guid FolderId { get; set; }
+
+    }
+}

--- a/src/Churchee.Module.Site/Features/Favicons/Commands/GenerateFaviconCommandHandler.cs
+++ b/src/Churchee.Module.Site/Features/Favicons/Commands/GenerateFaviconCommandHandler.cs
@@ -1,0 +1,143 @@
+﻿using Churchee.Common.Abstractions.Auth;
+using Churchee.Common.Abstractions.Utilities;
+using Churchee.Common.ResponseTypes;
+using Churchee.Common.Storage;
+using Churchee.Module.Site.Entities;
+using MediatR;
+
+
+namespace Churchee.Module.Site.Features.Favicons.Commands
+{
+    public class GenerateFaviconCommandHandler : IRequestHandler<GenerateFaviconCommand, CommandResponse>
+    {
+
+        private readonly IBlobStore _blobStore;
+        private readonly IDataStore _dataStore;
+        private readonly ICurrentUser _currentUser;
+        private readonly IImageProcessor _imageProcessor;
+
+        public GenerateFaviconCommandHandler(IBlobStore blobStore, IDataStore dataStore, ICurrentUser currentUser, IImageProcessor imageProcessor)
+        {
+            _blobStore = blobStore;
+            _dataStore = dataStore;
+            _currentUser = currentUser;
+            _imageProcessor = imageProcessor;
+        }
+
+        public async Task<CommandResponse> Handle(GenerateFaviconCommand request, CancellationToken cancellationToken)
+        {
+            byte[] data = Convert.FromBase64String(request.Base64Content.Split(',')[1]);
+
+            using var originalImageStream = new MemoryStream(data);
+
+            var applicationTenantId = await _currentUser.GetApplicationTenantId();
+
+            await CreatePngFavicon(originalImageStream, applicationTenantId, "android-chrome-", 512, cancellationToken);
+            await CreatePngFavicon(originalImageStream, applicationTenantId, "android-chrome-", 192, cancellationToken);
+            await CreatePngFavicon(originalImageStream, applicationTenantId, "favicon-", 48, cancellationToken);
+            await CreatePngFavicon(originalImageStream, applicationTenantId, "favicon-", 32, cancellationToken);
+            await CreatePngFavicon(originalImageStream, applicationTenantId, "favicon-", 16, cancellationToken);
+            await CreateAppleTouchIcon(originalImageStream, applicationTenantId, cancellationToken);
+            await CreateFavicon(originalImageStream, applicationTenantId, cancellationToken);
+            await CreateAdminThumbnail(originalImageStream, applicationTenantId, cancellationToken);
+
+            var media = new MediaItem(applicationTenantId, "Favicon", "/favicons/apple-touch-icon.png", string.Empty, string.Empty, request.FolderId, string.Empty, string.Empty);
+
+            _dataStore.GetRepository<MediaItem>().Create(media);
+
+            await _dataStore.SaveChangesAsync(cancellationToken);
+
+            return new CommandResponse();
+        }
+
+        private async Task CreatePngFavicon(MemoryStream originalImageStream, Guid applicationTenantId, string fileNamePrefix, int size, CancellationToken cancellationToken)
+        {
+            string imagePath = $"/favicons/{fileNamePrefix}{size}x{size}.png";
+
+            using var imageStream = await _imageProcessor.ResizeImageAsync(originalImageStream, size, 0, ".png", cancellationToken);
+
+            await _blobStore.SaveAsync(applicationTenantId, imagePath, imageStream, true, cancellationToken);
+
+            originalImageStream.Position = 0; // Reset stream position for next use
+        }
+
+        private async Task CreateAppleTouchIcon(MemoryStream originalImageStream, Guid applicationTenantId, CancellationToken cancellationToken)
+        {
+            string imagePath = $"/favicons/apple-touch-icon.png";
+
+            using var imageStream = await _imageProcessor.ResizeImageAsync(originalImageStream, 256, 0, ".png", cancellationToken);
+
+            await _blobStore.SaveAsync(applicationTenantId, imagePath, imageStream, true, cancellationToken);
+
+            originalImageStream.Position = 0; // Reset stream position for next use
+        }
+
+        private async Task CreateAdminThumbnail(MemoryStream originalImageStream, Guid applicationTenantId, CancellationToken cancellationToken)
+        {
+            string imagePath = $"/favicons/apple-touch-icon_s.png";
+
+            using var imageStream = await _imageProcessor.ResizeImageAsync(originalImageStream, 575, 0, ".png", cancellationToken);
+
+            await _blobStore.SaveAsync(applicationTenantId, imagePath, imageStream, true, cancellationToken);
+
+            originalImageStream.Position = 0; // Reset stream position for next use
+        }
+
+        private async Task CreateFavicon(MemoryStream originalImageStream, Guid applicationTenantId, CancellationToken cancellationToken)
+        {
+            int[] sizes = { 16, 32, 48, 256 };
+            var imageDataList = new List<byte[]>();
+
+            // Reset stream position before reading
+            originalImageStream.Position = 0;
+
+
+            foreach (int size in sizes)
+            {
+                using var imageStream = await _imageProcessor.ResizeImageAsync(originalImageStream, size, 0, ".png", cancellationToken);
+                imageStream.Position = 0;
+                using var ms = new MemoryStream();
+                imageStream.CopyTo(ms);
+                imageDataList.Add(ms.ToArray());
+                originalImageStream.Position = 0;
+            }
+
+            using var outStream = new MemoryStream();
+            using (var bw = new BinaryWriter(outStream, System.Text.Encoding.UTF8, true))
+            {
+                // ICONDIR header
+                bw.Write((short)0); // Reserved
+                bw.Write((short)1); // Type (1 = icon)
+                bw.Write((short)sizes.Length); // Number of images
+
+                int dataOffset = 6 + (16 * sizes.Length);
+
+                for (int i = 0; i < sizes.Length; i++)
+                {
+                    int size = sizes[i];
+                    byte[] imageData = imageDataList[i];
+
+                    bw.Write((byte)(size == 256 ? 0 : size)); // Width
+                    bw.Write((byte)(size == 256 ? 0 : size)); // Height
+                    bw.Write((byte)0); // Color palette
+                    bw.Write((byte)0); // Reserved
+                    bw.Write((short)1); // Color planes
+                    bw.Write((short)32); // Bits per pixel
+                    bw.Write(imageData.Length); // Image data size
+                    bw.Write(dataOffset); // Offset
+                    dataOffset += imageData.Length;
+                }
+
+                // Write image data
+                foreach (byte[] imageData in imageDataList)
+                {
+                    bw.Write(imageData);
+                }
+            }
+
+            outStream.Position = 0;
+            string icoPath = "/favicons/favicon.ico";
+            await _blobStore.SaveAsync(applicationTenantId, icoPath, outStream, true, cancellationToken);
+        }
+    }
+}

--- a/src/Churchee.Module.Site/Features/Favicons/Commands/GenerateFaviconCommandValidator.cs
+++ b/src/Churchee.Module.Site/Features/Favicons/Commands/GenerateFaviconCommandValidator.cs
@@ -1,0 +1,63 @@
+﻿using Churchee.ImageProcessing.Validation;
+using FluentValidation;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Churchee.Module.Site.Features.Favicons.Commands
+{
+
+    public class GenerateFaviconCommandValidator : AbstractValidator<GenerateFaviconCommand>
+    {
+        public GenerateFaviconCommandValidator()
+        {
+            RuleFor(x => x.Base64Content)
+                .Must(ImageValidation.BeValidImage)
+                .WithMessage("Uploaded file doesn't appear to be an image.");
+
+            RuleFor(x => x.Base64Content)
+                .Must((image, base64Image) => ImageValidation.BeExpectedFormat(base64Image, ".png"))
+                .WithMessage("Must be a png");
+
+            RuleFor(x => x.Base64Content)
+                .Must(BeSquare)
+                .WithMessage("Image must be square");
+
+            RuleFor(x => x.Base64Content)
+                .Must(BeMoreThen575)
+                .WithMessage("Image must be more then 575px");
+        }
+
+        private bool BeSquare(string base64Image)
+        {
+            try
+            {
+                string base64 = base64Image.Contains(",") ? base64Image.Split(',')[1] : base64Image;
+                byte[] imageBytes = Convert.FromBase64String(base64);
+                using var ms = new System.IO.MemoryStream(imageBytes);
+                using var image = Image.Load<Rgba32>(ms);
+                return image.Width == image.Height;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private bool BeMoreThen575(string base64Image)
+        {
+            try
+            {
+                string base64 = base64Image.Contains(",") ? base64Image.Split(',')[1] : base64Image;
+                byte[] imageBytes = Convert.FromBase64String(base64);
+                using var ms = new System.IO.MemoryStream(imageBytes);
+                using var image = Image.Load<Rgba32>(ms);
+                return image.Width > 575;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+    }
+}

--- a/src/Churchee.Module.Site/Features/Media/Queries/GetMediaFolders/GetMediaFoldersQueryHandler.cs
+++ b/src/Churchee.Module.Site/Features/Media/Queries/GetMediaFolders/GetMediaFoldersQueryHandler.cs
@@ -58,6 +58,11 @@ namespace Churchee.Module.Site.Features.Media.Queries
                 repo.Create(new MediaFolder(applicationTenantId, "Images", ".jpg, .jpeg, .png, .webp"));
             }
 
+            if (!repo.AnyWithFiltersDisabled(a => a.ApplicationTenantId == applicationTenantId && a.ParentId == null && a.Path == "Favicons/"))
+            {
+                repo.Create(new MediaFolder(applicationTenantId, "Favicons", ".png"));
+            }
+
             await _storage.SaveChangesAsync(cancellationToken);
 
         }

--- a/test/Churchee.Module.Site.Tests/Areas/Site/Models/CreateFaviconModelTests.cs
+++ b/test/Churchee.Module.Site.Tests/Areas/Site/Models/CreateFaviconModelTests.cs
@@ -1,0 +1,29 @@
+using Churchee.Module.Site.Areas.Site.Models;
+using System.ComponentModel.DataAnnotations;
+
+namespace Churchee.Module.Site.Tests.Areas.Site.Models
+{
+    public class CreateFaviconModelTests
+    {
+        [Fact]
+        public void File_IsRequired()
+        {
+            var model = new CreateFaviconModel
+            {
+                File = null
+            };
+
+            var results = ValidateModel(model);
+
+            Assert.Contains(results, r => r.MemberNames.Contains(nameof(CreateFaviconModel.File)) && (r.ErrorMessage != null) && r.ErrorMessage.Contains("required", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static List<ValidationResult> ValidateModel(object model)
+        {
+            var results = new List<ValidationResult>();
+            var context = new ValidationContext(model, null, null);
+            Validator.TryValidateObject(model, context, results, true);
+            return results;
+        }
+    }
+}

--- a/test/Churchee.Module.Site.Tests/Features/Favicons/GenerateFaviconCommandHandlerTests.cs
+++ b/test/Churchee.Module.Site.Tests/Features/Favicons/GenerateFaviconCommandHandlerTests.cs
@@ -1,0 +1,79 @@
+﻿using Churchee.Common.Abstractions.Auth;
+using Churchee.Common.Abstractions.Storage;
+using Churchee.Common.Abstractions.Utilities;
+using Churchee.Common.Storage;
+using Churchee.Module.Site.Entities;
+using Churchee.Module.Site.Features.Favicons.Commands;
+using Moq;
+
+namespace Churchee.Module.Site.Tests.Features.Favicons
+{
+    public class GenerateFaviconCommandHandlerTests
+    {
+        private readonly Mock<IBlobStore> _blobStoreMock = new();
+        private readonly Mock<IDataStore> _dataStoreMock = new();
+        private readonly Mock<ICurrentUser> _currentUserMock = new();
+        private readonly Mock<IImageProcessor> _imageProcessorMock = new();
+        private readonly Mock<IRepository<MediaItem>> _mediaRepoMock = new();
+
+        private GenerateFaviconCommandHandler CreateHandler()
+        {
+            _dataStoreMock.Setup(ds => ds.GetRepository<MediaItem>()).Returns(_mediaRepoMock.Object);
+            return new GenerateFaviconCommandHandler(
+                _blobStoreMock.Object,
+                _dataStoreMock.Object,
+                _currentUserMock.Object,
+                _imageProcessorMock.Object
+            );
+        }
+
+        [Fact]
+        public async Task Handle_ShouldProcessAndSaveAllFavicons()
+        {
+            // Arrange
+            var tenantId = Guid.NewGuid();
+            var folderId = Guid.NewGuid();
+            string base64 = "data:image/png;base64," + Convert.ToBase64String(new byte[] { 1, 2, 3, 4 });
+            var command = new GenerateFaviconCommand(base64, folderId);
+
+            _currentUserMock.Setup(cu => cu.GetApplicationTenantId()).ReturnsAsync(tenantId);
+
+            // Setup image processor to return a dummy stream for any resize
+            _imageProcessorMock
+                .Setup(ip => ip.ResizeImageAsync(It.IsAny<Stream>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new MemoryStream([5, 6, 7, 8]));
+
+            // Setup blob store to just return the path
+            _blobStoreMock
+                .Setup(bs => bs.SaveAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Stream>(), true, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Guid id, string path, Stream s, bool o, CancellationToken t) => path);
+
+            // Setup repository and data store
+            _mediaRepoMock.Setup(r => r.Create(It.IsAny<MediaItem>()));
+            _dataStoreMock.Setup(ds => ds.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            var handler = CreateHandler();
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.True(result.IsSuccess);
+
+            // Verify that all expected images are saved
+            _blobStoreMock.Verify(bs => bs.SaveAsync(tenantId, "/favicons/android-chrome-512x512.png", It.IsAny<Stream>(), true, It.IsAny<CancellationToken>()), Times.Once);
+            _blobStoreMock.Verify(bs => bs.SaveAsync(tenantId, "/favicons/android-chrome-192x192.png", It.IsAny<Stream>(), true, It.IsAny<CancellationToken>()), Times.Once);
+            _blobStoreMock.Verify(bs => bs.SaveAsync(tenantId, "/favicons/favicon-48x48.png", It.IsAny<Stream>(), true, It.IsAny<CancellationToken>()), Times.Once);
+            _blobStoreMock.Verify(bs => bs.SaveAsync(tenantId, "/favicons/favicon-32x32.png", It.IsAny<Stream>(), true, It.IsAny<CancellationToken>()), Times.Once);
+            _blobStoreMock.Verify(bs => bs.SaveAsync(tenantId, "/favicons/favicon-16x16.png", It.IsAny<Stream>(), true, It.IsAny<CancellationToken>()), Times.Once);
+            _blobStoreMock.Verify(bs => bs.SaveAsync(tenantId, "/favicons/apple-touch-icon.png", It.IsAny<Stream>(), true, It.IsAny<CancellationToken>()), Times.Once);
+            _blobStoreMock.Verify(bs => bs.SaveAsync(tenantId, "/favicons/favicon.ico", It.IsAny<Stream>(), true, It.IsAny<CancellationToken>()), Times.Once);
+            _blobStoreMock.Verify(bs => bs.SaveAsync(tenantId, "/favicons/apple-touch-icon_s.png", It.IsAny<Stream>(), true, It.IsAny<CancellationToken>()), Times.Once);
+
+            // Verify that media item is created and changes are saved
+            _mediaRepoMock.Verify(r => r.Create(It.IsAny<MediaItem>()), Times.Once);
+            _dataStoreMock.Verify(ds => ds.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/test/Churchee.Module.Site.Tests/Features/Favicons/GenerateFaviconCommandTests.cs
+++ b/test/Churchee.Module.Site.Tests/Features/Favicons/GenerateFaviconCommandTests.cs
@@ -1,0 +1,22 @@
+﻿using Churchee.Module.Site.Features.Favicons.Commands;
+
+namespace Churchee.Module.Site.Tests.Features.Favicons
+{
+    public class GenerateFaviconCommandTests
+    {
+
+        [Fact]
+        public void GenerateFaviconCommand_InitializesProperties()
+        {
+            // Arrange
+            string base64Content = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...";
+            var folderId = Guid.NewGuid();
+            // Act
+            var command = new GenerateFaviconCommand(base64Content, folderId);
+            // Assert
+            Assert.Equal(base64Content, command.Base64Content);
+            Assert.Equal(folderId, command.FolderId);
+        }
+
+    }
+}

--- a/test/Churchee.Module.Site.Tests/Features/Favicons/GenerateFaviconCommandValidatorTests.cs
+++ b/test/Churchee.Module.Site.Tests/Features/Favicons/GenerateFaviconCommandValidatorTests.cs
@@ -1,0 +1,89 @@
+using Churchee.Module.Site.Features.Favicons.Commands;
+using FluentValidation.TestHelper;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Churchee.Module.Site.Tests.Features.Favicons
+{
+    public class GenerateFaviconCommandValidatorTests
+    {
+        private static string CreateBase64Png(int width, int height)
+        {
+            using var image = new Image<Rgba32>(width, height);
+            using var ms = new MemoryStream();
+            image.Save(ms, new PngEncoder());
+            string base64 = Convert.ToBase64String(ms.ToArray());
+            return $"data:image/png;base64,{base64}";
+        }
+
+        private static string CreateBase64Jpeg(int width, int height)
+        {
+            using var image = new Image<Rgba32>(width, height);
+            using var ms = new MemoryStream();
+            image.SaveAsJpeg(ms);
+            string base64 = Convert.ToBase64String(ms.ToArray());
+            return $"data:image/jpeg;base64,{base64}";
+        }
+
+        [Fact]
+        public void ValidPngSquareAndLargeEnough_ShouldBeValid()
+        {
+            string base64 = CreateBase64Png(600, 600);
+            var command = new GenerateFaviconCommand(base64, Guid.NewGuid());
+            var validator = new GenerateFaviconCommandValidator();
+
+            var result = validator.TestValidate(command);
+
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
+        public void NotAnImage_ShouldBeInvalid()
+        {
+            string base64 = "data:image/png;base64,notarealbase64string";
+            var command = new GenerateFaviconCommand(base64, Guid.NewGuid());
+            var validator = new GenerateFaviconCommandValidator();
+
+            var result = validator.TestValidate(command);
+
+            Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("doesn't appear to be an image"));
+        }
+
+        [Fact]
+        public void NotPng_ShouldBeInvalid()
+        {
+            string base64 = CreateBase64Jpeg(600, 600);
+            var command = new GenerateFaviconCommand(base64, Guid.NewGuid());
+            var validator = new GenerateFaviconCommandValidator();
+
+            var result = validator.TestValidate(command);
+
+            Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("Must be a png"));
+        }
+
+        [Fact]
+        public void NotSquare_ShouldBeInvalid()
+        {
+            string base64 = CreateBase64Png(600, 400);
+            var command = new GenerateFaviconCommand(base64, Guid.NewGuid());
+            var validator = new GenerateFaviconCommandValidator();
+
+            var result = validator.TestValidate(command);
+
+            Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("square"));
+        }
+
+        [Fact]
+        public void TooSmall_ShouldBeInvalid()
+        {
+            string base64 = CreateBase64Png(400, 400);
+            var command = new GenerateFaviconCommand(base64, Guid.NewGuid());
+            var validator = new GenerateFaviconCommandValidator();
+
+            var result = validator.TestValidate(command);
+
+            Assert.Contains(result.Errors, e => e.ErrorMessage.Contains("more then 575px"));
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature for uploading and generating favicons within the media management section. It adds support for validating, processing, and storing favicon images, including backend command handling, validation, and tests. The changes also ensure the presence of a dedicated "Favicons" folder and update the UI to support the new workflow.

**Favicon Upload and Generation Feature:**

* Added `CreateFaviconModel` and integrated it into the media management UI to allow users to upload and submit favicon images. [[1]](diffhunk://#diff-8234c9a7ac49c4305a524fb66a1ad98889870a07a0b9e4c93f3614a0ab68aa01R1-R18) [[2]](diffhunk://#diff-5ac88159f39d1e91f2610582c3626dcf1650e9508b184d039c20266d2399f2bcR4) [[3]](diffhunk://#diff-5ac88159f39d1e91f2610582c3626dcf1650e9508b184d039c20266d2399f2bcR155-R156) [[4]](diffhunk://#diff-5ac88159f39d1e91f2610582c3626dcf1650e9508b184d039c20266d2399f2bcR214-R271)
* Implemented `GenerateFaviconCommand`, its handler, and validator to process uploaded images, generate multiple favicon sizes and formats, and store them in the blob store and database. [[1]](diffhunk://#diff-478d60bcf976771831730a7d162f4e65bff78110f9cd10affe45f06d842b7242R1-R19) [[2]](diffhunk://#diff-601087c050aa2de403e455b57b5f3d802522818e8fdcdace43caf52b785c5a6cR1-R143) [[3]](diffhunk://#diff-9b37154d8b7a001994b45cccf4a2274772008151a2e79271036f633cf948682eR1-R63)
* Ensured the "Favicons" media folder is automatically created if missing, supporting the new workflow.

**Testing and Validation:**

* Added unit tests for the `CreateFaviconModel` validation, `GenerateFaviconCommand` property initialization, and the favicon generation handler's end-to-end behavior. [[1]](diffhunk://#diff-aa4f0f06b63f2f78b2f77c5ad6e300d8a70d891e268dd78a08da1a968b5088bdR1-R29) [[2]](diffhunk://#diff-cb8ac9850425043c5a1e371f8dfa502a7dacd73a1092ffabf0cd53c4bd13099bR1-R22) [[3]](diffhunk://#diff-a5609c1a9d6d9d3280f74e5ada33466bed83263e355aab0d5be21f08cb79ba89R1-R79)